### PR TITLE
docs: fix README clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ A powerful, modern web application for analyzing JavaScript files to detect sens
 
 1. **Clone the repository**
 ```bash
-git clone https://github.com/zack0X01/js-analysis
-cd js-analysis
+git clone https://github.com/zack0x01/JS-Analyser
+cd JS-Analyser
 ```
 
 2. **Install dependencies**
@@ -199,4 +199,3 @@ This tool is for **authorized security testing and educational purposes only**. 
 ---
 
 ⭐ If you find this tool useful, please give it a star on GitHub!
-


### PR DESCRIPTION
## Summary
- update the README clone command to the current repository URL
- update the matching `cd` command to the directory created by that clone

## Validation
- `git ls-remote --heads https://github.com/zack0X01/js-analysis.git main` returned 128
- `git ls-remote --heads https://github.com/zack0x01/JS-Analyser.git main` returned the `main` branch
- shallow-cloned `https://github.com/zack0x01/JS-Analyser` and confirmed it creates `JS-Analyser/README.md`
- `git diff --check`

No application tests were run because this only updates README installation commands.

Fixes #2.